### PR TITLE
Change database query from First to Find

### DIFF
--- a/backend/repository/user.go
+++ b/backend/repository/user.go
@@ -282,7 +282,7 @@ func (r *User) GetAllAPIKeys(
 	dbUsers := []database.User{}
 	result := r.DB.
 		Select("id, api_key").
-		First(&dbUsers)
+		Find(&dbUsers)
 
 	if result.Error != nil {
 		return apiKeys, result.Error


### PR DESCRIPTION
This should allow all API-keys to be found and authenticated (not only the first one).

This change is not tested though.